### PR TITLE
Changing '-g -O2' to '-g -Og'. If you want to enable optimization and…

### DIFF
--- a/configure
+++ b/configure
@@ -3522,7 +3522,7 @@ if test "$ac_test_CFLAGS" = set; then
   CFLAGS=$ac_save_CFLAGS
 elif test $ac_cv_prog_cc_g = yes; then
   if test "$GCC" = yes; then
-    CFLAGS="-g -O2"
+    CFLAGS="-g -Og"
   else
     CFLAGS="-g"
   fi


### PR DESCRIPTION
… debugging information, you should use '-Og' in order to make sure that optimizations won't get in the way of debugging.