### PR TITLE
Backport statue patch from 3.6.0

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -276,7 +276,8 @@
 #define GLYPH_ZAP_OFF		((MAXEXPCHARS * EXPL_MAX) + GLYPH_EXPLODE_OFF)
 #define GLYPH_SWALLOW_OFF	((NUM_ZAP << 2) + GLYPH_ZAP_OFF)
 #define GLYPH_WARNING_OFF	((NUMMONS << 3) + GLYPH_SWALLOW_OFF)
-#define MAX_GLYPH		(WARNCOUNT      + GLYPH_WARNING_OFF)
+#define GLYPH_STATUE_OFF       (WARNCOUNT	+ GLYPH_WARNING_OFF)
+#define MAX_GLYPH		(NUMMONS      + GLYPH_STATUE_OFF)
 
 #define NO_GLYPH MAX_GLYPH
 
@@ -290,7 +291,22 @@
 
 /* This has the unfortunate side effect of needing a global variable	*/
 /* to store a result. 'otg_temp' is defined and declared in decl.{ch}.	*/
+#define random_obj_to_glyph() 					    	      \
+	((otg_temp = random_object()) == CORPSE ?			      \
+	    random_monster() + GLYPH_BODY_OFF :				      \
+	        otg_temp + GLYPH_OBJ_OFF)
+
 #define obj_to_glyph(obj)						      \
+    ((obj)->otyp == STATUE ?						      \
+        statue_to_glyph(obj) :				       	      	      \
+     Hallucination ?	  				       	      	      \
+	random_obj_to_glyph() :			       	      	      	      \
+     (obj)->otyp == CORPSE ?					      	      \
+	    (int) (obj)->corpsenm + GLYPH_BODY_OFF :			      \
+	(int) (obj)->otyp + GLYPH_OBJ_OFF)
+
+
+#define obj_to_glyph_vanilla(obj)                    \
     (Hallucination ?							      \
 	((otg_temp = random_object()) == CORPSE ?			      \
 	    random_monster() + GLYPH_BODY_OFF :				      \
@@ -303,10 +319,19 @@
 #define explosion_to_glyph(expltype,idx)	\
 		((((expltype) * MAXEXPCHARS) + ((idx) - S_explode1)) + GLYPH_EXPLODE_OFF)
 
+/* MRKR: Statues now have glyphs corresponding to the monster they    */
+/*       brepresent and look like monsters when you are hallucinating. */
+
+#define statue_to_glyph(obj)						      \
+    (Hallucination ?							      \
+	random_monster() + GLYPH_MON_OFF :				      \
+	(int) (obj)->corpsenm + GLYPH_STATUE_OFF)
+
 #define trap_to_glyph(trap)	\
 			cmap_to_glyph(trap_to_defsym(what_trap((trap)->ttyp)))
 
 /* Not affected by hallucination.  Gives a generic body for CORPSE */
+/* MRKR: ...and the generic statue */
 #define objnum_to_glyph(onum)	((int) (onum) + GLYPH_OBJ_OFF)
 #define monnum_to_glyph(mnum)	((int) (mnum) + GLYPH_MON_OFF)
 #define detected_monnum_to_glyph(mnum)	((int) (mnum) + GLYPH_DETECT_OFF)
@@ -338,9 +363,11 @@
 	glyph_is_pet(glyph) ? ((glyph)-GLYPH_PET_OFF) :			\
 	glyph_is_detected_monster(glyph) ? ((glyph)-GLYPH_DETECT_OFF) :	\
 	glyph_is_ridden_monster(glyph) ? ((glyph)-GLYPH_RIDDEN_OFF) :	\
+	glyph_is_statue(glyph) ? ((glyph)-GLYPH_STATUE_OFF) :		\
 	NO_GLYPH)
 #define glyph_to_obj(glyph)						\
 	(glyph_is_body(glyph) ? CORPSE :				\
+	glyph_is_statue(glyph) ? STATUE :				\
 	glyph_is_normal_object(glyph) ? ((glyph)-GLYPH_OBJ_OFF) :	\
 	NO_GLYPH)
 #define glyph_to_trap(glyph)						\
@@ -372,6 +399,12 @@
     ((glyph) >= GLYPH_PET_OFF && (glyph) < (GLYPH_PET_OFF+NUMMONS))
 #define glyph_is_body(glyph)						\
     ((glyph) >= GLYPH_BODY_OFF && (glyph) < (GLYPH_BODY_OFF+NUMMONS))
+
+#define glyph_is_statue(glyph)						\
+    ((glyph) >= GLYPH_STATUE_OFF && (glyph) < (GLYPH_STATUE_OFF+NUMMONS))
+#define GLYPH_STATUE_VANILLA  ((int) GLYPH_OBJ_OFF + STATUE)
+#define glyph_is_statue_vanilla(glyph) ( glyph == GLYPH_STATUE_VANILLA)
+
 #define glyph_is_ridden_monster(glyph)					\
     ((glyph) >= GLYPH_RIDDEN_OFF && (glyph) < (GLYPH_RIDDEN_OFF+NUMMONS))
 #define glyph_is_detected_monster(glyph)				\
@@ -381,6 +414,7 @@
     ((glyph) >= GLYPH_OBJ_OFF && (glyph) < (GLYPH_OBJ_OFF+NUM_OBJECTS))
 #define glyph_is_object(glyph)						\
 		(glyph_is_normal_object(glyph)				\
+		|| glyph_is_statue(glyph)				\
 		|| glyph_is_body(glyph))
 #define glyph_is_trap(glyph)						\
     ((glyph) >= (GLYPH_CMAP_OFF+trap_to_defsym(1)) &&			\

--- a/include/hack.h
+++ b/include/hack.h
@@ -55,6 +55,7 @@
 #define MG_PET		0x08
 #define MG_RIDDEN	0x10
 #define MG_INVERSE	0x20 /* use inverse video */
+#define MG_STATUE	0x40
 
 /* sellobj_state() states */
 #define SELL_NORMAL	(0)

--- a/src/display.c
+++ b/src/display.c
@@ -255,7 +255,18 @@ map_object(obj, show)
     register int x = obj->ox, y = obj->oy;
     register int glyph = obj_to_glyph(obj);
 
-    if (level.flags.hero_memory)
+    if (level.flags.hero_memory) {
+
+	/* MRKR: While hallucinating, statues are seen as random monsters */
+	/*       but remembered as random objects.                        */
+
+		if (Hallucination && obj->otyp == STATUE) {
+			levl[x][y].glyph = random_obj_to_glyph();
+		}
+		else {
+			levl[x][y].glyph = glyph;
+		}
+	}
 	levl[x][y].glyph = glyph;
     if (show) show_glyph(x, y, glyph);
 }
@@ -1236,7 +1247,8 @@ show_glyph(x,y,glyph)
 	 *  the definition.
 	 */
 
-	if (glyph >= GLYPH_WARNING_OFF) {	/* a warning */
+	if (glyph >= GLYPH_WARNING_OFF
+            && glyph < GLYPH_STATUE_OFF) {	/* a warning */
 	    text = "warning";		offset = glyph - GLYPH_WARNING_OFF;
 	} else if (glyph >= GLYPH_SWALLOW_OFF) {	/* swallow border */
 	    text = "swallow border";	offset = glyph - GLYPH_SWALLOW_OFF;

--- a/src/mapglyph.c
+++ b/src/mapglyph.c
@@ -109,7 +109,16 @@ unsigned *ospecial;
      *  Warning:  For speed, this makes an assumption on the order of
      *		  offsets.  The order is set in display.h.
      */
-    if ((offset = (glyph - GLYPH_WARNING_OFF)) >= 0) {	/* a warning flash */
+    if ((offset = (glyph - GLYPH_STATUE_OFF)) >= 0) {   /* a statue */
+	ch = get_monsym(offset);
+# ifdef ROGUE_COLOR
+	if (has_rogue_color)
+		color = CLR_RED;
+	else
+# endif
+	obj_color(STATUE);
+	special |= MG_STATUE;
+    } else if ((offset = (glyph - GLYPH_WARNING_OFF)) >= 0) {	/* a warning flash */
     	ch = warnsyms[offset];
 # ifdef ROGUE_COLOR
 	if (HAS_ROGUE_IBM_GRAPHICS)

--- a/src/pager.c
+++ b/src/pager.c
@@ -545,6 +545,8 @@ do_look(quick)
 		}
 	    } else if (glyph_is_trap(glyph)) {
 		sym = showsyms[trap_to_defsym(glyph_to_trap(glyph))];
+	    } else if (glyph_is_statue(glyph)) {
+	        sym = monsyms[(int)mons[glyph_to_mon(glyph)].mlet];
 	    } else if (glyph_is_object(glyph)) {
 		sym = oc_syms[(int)objects[glyph_to_obj(glyph)].oc_class];
 		if (sym == '`' && iflags.bouldersym && (int)glyph_to_obj(glyph) == BOULDER)

--- a/src/restore.c
+++ b/src/restore.c
@@ -57,6 +57,7 @@ extern int amii_numcolors;
 #endif
 
 #include "quest.h"
+#include "display.h"
 
 boolean restoring = FALSE;
 static NEARDATA struct fruit *oldfruit;
@@ -93,6 +94,15 @@ find_lev_obj()
 		fobjtmp = otmp->nobj;
 		place_object(otmp, otmp->ox, otmp->oy);
 	}
+
+	/* statue patch: imagine we're loading a vanilla nh file */
+	for(x=0; x<COLNO; x++)
+          for(y=0; y<ROWNO; y++)
+            if ( level.objects[x][y] != 0 &&
+                 level.objects[x][y]->otyp == STATUE &&
+		 glyph_is_statue_vanilla(levl[x][y].glyph))  {
+              levl[x][y].glyph = obj_to_glyph(level.objects[x][y]);
+            }
 }
 
 /* Things that were marked "in_use" when the game was saved (ex. via the

--- a/src/save.c
+++ b/src/save.c
@@ -50,6 +50,23 @@ static long nulls[10];
 #define HUP
 #endif
 
+
+/* compute object glyphs for vanilla nethack -- statue patch */
+void
+make_glyphs_vanilla(lev)
+xchar lev;
+{
+  int x,y;
+
+  for (x = 0; x < COLNO; x++)
+    for (y = 0; y < ROWNO; y++)
+      if ( level.objects[x][y] != 0 &&
+           level.objects[x][y]->otyp == STATUE &&
+           glyph_is_statue(levl[x][y].glyph))
+             levl[x][y].glyph = obj_to_glyph_vanilla(level.objects[x][y]);
+}
+
+
 #ifdef MENU_COLOR
 extern struct menucoloring *menu_colorings;
 #endif
@@ -475,6 +492,9 @@ int mode;
 #ifdef TOS
 	short tlev;
 #endif
+
+        /* make remembered glyphs correct fo rloading into vanilla nh */
+        make_glyphs_vanilla(lev);
 
 	/* if we're tearing down the current level without saving anything
 	   (which happens upon entrance to the endgame or after an aborted

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -1068,6 +1068,23 @@ dochat()
     tx = u.ux+u.dx; ty = u.uy+u.dy;
     mtmp = m_at(tx, ty);
 
+    if ((!mtmp || mtmp->mundetected) &&
+	(otmp = vobj_at(tx, ty)) && otmp->otyp == STATUE) {
+
+      /* Talking to a statue */
+
+      if (!Blind) {
+	if (Hallucination) {
+	  /* if you're hallucinating, you can't tell it's a statue */
+	  pline_The("%s seems not to notice you.", rndmonnam());
+	}
+	else {
+	  pline_The("statue seems not to notice you.");
+	}
+      }
+      return(0);
+    }
+
     if (!mtmp || mtmp->mundetected ||
 		mtmp->m_ap_type == M_AP_FURNITURE ||
 		mtmp->m_ap_type == M_AP_OBJECT)

--- a/src/trap.c
+++ b/src/trap.c
@@ -510,7 +510,9 @@ int *fail_reason;
 	    if (historic) {
 		    You_feel("guilty that the historic statue is now gone.");
 		    adjalign(-1);
-	    }
+        }
+    } else if (Hallucination) {    /* They don't know it's a statue */
+	    pline_The("%s suddenly seems more animated.", rndmonnam());
 	} else if (cause == ANIMATE_SHATTER)
 	    pline("Instead of shattering, the statue suddenly %s!",
 		canspotmon(mon) ? "comes to life" : "disappears");

--- a/src/zap.c
+++ b/src/zap.c
@@ -1614,10 +1614,20 @@ struct obj *obj, *otmp;
 		break;
 	case WAN_STRIKING:
 	case SPE_FORCE_BOLT:
-		if (obj->otyp == BOULDER)
+		if (obj->otyp == BOULDER) {
+			if (cansee(obj->ox, obj->oy))
+				pline_The("boulder falls apart.");
 			fracture_rock(obj);
-		else if (obj->otyp == STATUE)
-			(void) break_statue(obj);
+		} else if (obj->otyp == STATUE) {
+			if (break_statue(obj)) {
+				if (cansee(obj->ox, obj->oy)) {
+					if (Hallucination)
+						pline_The("%s shatters.", rndmonnam());
+					else
+						pline_The("statue shatters.");
+				}
+			}
+		}
 		else {
 			if (!flags.mon_moving)
 			    (void)hero_breaks(obj, obj->ox, obj->oy, FALSE);

--- a/win/share/tilemap.c
+++ b/win/share/tilemap.c
@@ -429,6 +429,12 @@ init_tilemap()
 		tilenum++;
 	}
 
+	/* statue patch: statues still use the same glyph as in vanilla */
+
+	for ( i = 0; i < NUMMONS; i++) {
+	        tilemap[GLYPH_STATUE_OFF+i] = tilemap[GLYPH_OBJ_OFF+STATUE];
+        }
+
 	lastothtile = tilenum - 1;
 }
 


### PR DESCRIPTION
Statue patch makes ugly backtick statues appear as appropriate monster characters.

Signed-off-by: Vitaly Ostrosablin <vostrosablin@virtuozzo.com>