### PR TITLE
Add convict corpse to massacre vault

### DIFF
--- a/dat/vaults.des
+++ b/dat/vaults.des
@@ -197,7 +197,7 @@ ROOM:"rndvault", random, random, random, random {
   $mon = MONSTER: { '@', "apprentice", "warrior", "ninja", "thug", "hunter", "acolyte", "abbot",
              "page", "attendant", "neanderthal", "chieftain", "student", "wizard", "valkyrie",
 	     "tourist", "samurai", "rogue", "ranger", "priestess", "priest", "monk",
-             "knight", "healer", "cavewoman", "caveman", "barbarian", "archeologist" }
+             "knight", "healer", "cavewoman", "caveman", "barbarian", "archeologist", "convict"}
   SHUFFLE: $mon
   LOOP [5d5] {
     [10%]: SHUFFLE: $mon


### PR DESCRIPTION
Because the vault was created before Convict patch was merged in,
there's no convict corpse in the random generation list. This patch
fixes this.

Fixes #21 

Signed-off-by: Vitaly Ostrosablin <vostrosablin@virtuozzo.com>