### PR TITLE
Fix bison 3.7 include header error

### DIFF
--- a/util/dgn_comp.y
+++ b/util/dgn_comp.y
@@ -63,6 +63,8 @@ extern FILE *yyin, *yyout;	/* from dgn_lex.c */
 
 %}
 
+%define api.header.include {"dgn_comp.h"}
+
 %union
 {
 	int	i;

--- a/util/lev_comp.y
+++ b/util/lev_comp.y
@@ -150,6 +150,8 @@ extern int rnd_vault_freq;
 
 %}
 
+%define api.header.include {"lev_comp.h"}
+
 %union
 {
 	long	i;


### PR DESCRIPTION
The build [fails](https://nix-cache.s3.amazonaws.com/log/w9h76mawgy9w7rkbcahlz9zmwc8hg1cg-unnethack-5.2.0.drv) after upgrading to bison 3.7:
```
( cd util ; make lev_comp )
make[1]: Entering directory '/build/UnNetHack/util'
bison -y  -b lev -d ./lev_comp.y
mv lev.tab.c lev_yacc.c
mv lev.tab.h ../include/lev_comp.h
gcc -DAUTOCONF -O2 -I../include -I./../include -g -O2   -c -o lev_yacc.o lev_yacc.c
lev.tab.c:245:10: fatal error: lev.tab.h: No such file or directory
compilation terminated.
make[1]: *** [<builtin>: lev_yacc.o] Error 1
```
This seems to be due to a change in how Bison handles definitions; it used to include them in both the header and the file, but now generates an ``#include <header>`` in the file. Setting the filename fixes it. Regenerating the build scripts using more recent autoconf/automake should also work.