### PR TITLE
Prefer linking to libncursesw

### DIFF
--- a/configure
+++ b/configure
@@ -5668,7 +5668,7 @@ return tparm ();
   return 0;
 }
 _ACEOF
-for ac_lib in '' ncurses curses tinfo
+for ac_lib in '' ncursesw ncurses curses tinfo
 do
   if test -z "$ac_lib"; then
     ac_res="none required"
@@ -5707,7 +5707,7 @@ printf "%s\n" "#define HAVE_TPARM 1" >>confdefs.h
 
 fi
 
-        TERMLIB_VARIANTS="ncurses curses tinfo termlib termcap terminfo"
+        TERMLIB_VARIANTS="ncursesw ncurses curses tinfo termlib termcap terminfo"
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing has_colors" >&5
 printf %s "checking for library containing has_colors... " >&6; }
 if test ${ac_cv_search_has_colors+y}

--- a/sys/autoconf/configure.ac
+++ b/sys/autoconf/configure.ac
@@ -142,8 +142,8 @@ if test "$enable_tty_graphics" != "no"; then
         dnl  ----- Check for tparm in curses
         LIBS=
         AC_CHECK_HEADERS(ncurses.h curses.h termcap.h)
-        AC_SEARCH_LIBS([tparm], [ncurses curses tinfo], AC_DEFINE(HAVE_TPARM, 1, [Define this if you have the tparm function in an included lib.]))
-        TERMLIB_VARIANTS="ncurses curses tinfo termlib termcap terminfo"
+        AC_SEARCH_LIBS([tparm], [ncursesw ncurses curses tinfo], AC_DEFINE(HAVE_TPARM, 1, [Define this if you have the tparm function in an included lib.]))
+        TERMLIB_VARIANTS="ncursesw ncurses curses tinfo termlib termcap terminfo"
         AC_SEARCH_LIBS([has_colors], ${TERMLIB_VARIANTS},
                      [WINTTYLIB="${LIBS}"
                       WINSRC="${WINSRC} \$(WINTTYSRC)"


### PR DESCRIPTION
ncursesw is ncurses + Unicode (UTF8) support. If not found it'll just link to `libncurses`, others like before.

May circumvent display issues wrt calculating the widths-on-terminal of Unicode characters.