### PR TITLE
[Upstream patch] Fix build against Glibc 2.35

### DIFF
--- a/include/tradstdc.h
+++ b/include/tradstdc.h
@@ -429,10 +429,12 @@ typedef genericptr genericptr_t;    /* (void *) or (char *) */
 #if __GNUC__ >= 3
 #define UNUSED __attribute__((unused))
 #define NORETURN __attribute__((noreturn))
+#if !defined(__linux__) || defined(GCC_URWARN)
 /* disable gcc's __attribute__((__warn_unused_result__)) since explicitly
    discarding the result by casting to (void) is not accepted as a 'use' */
 #define __warn_unused_result__ /*empty*/
 #define warn_unused_result /*empty*/
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
**Note:** I didn't write this; this cherry-picks commit https://github.com/NetHack/NetHack/commit/1cb5dc04605daa45f1c6a647c17442ed7ff2fe4e, fixing an issue where builds would fail against newer versions of glibc.

(The commit message says it fixes builds on Ubuntu 20.10, but that's not at the heart of the issue.)

Turns out glibc doesn't take kindly to un-defining some of its macros.

This is the error message this fixes (GCC 11.3.0 + glibc 2.35 on Linux x86_64):

```
cc -DAUTOCONF -Wall -I../include -I./../include -O2 -DHACKDIR=\"/var/lib/games/unnethack\"  -c ./monst.c
In file included from /usr/include/features.h:490,
                 from /usr/include/inttypes.h:25,
                 from ../include/config.h:306,
                 from ./monst.c:4:
/usr/include/sys/cdefs.h:405:73: error: macro "__has_attribute" requires an identifier
  405 | #if __GNUC_PREREQ (3,4) || __glibc_has_attribute (__warn_unused_result__)
      |                                                                         ^
make[1]: *** [Makefile:367: monst.o] Error 1
make[1]: Leaving directory '/usr/src/git/unnethack/src'
make: *** [Makefile:143: unnethack] Error 2
```

<details>
<summary>Full build output (160 lines)</summary>

```
configure: creating cache config.cache
checking whether ln -s works... yes
checking for gawk... gawk
checking dummy-graphics... no
checking lisp-graphics... no
checking curses-graphics... yes
checking tty-graphics... yes
checking x11-graphics... no
checking mswin-graphics... no
checking for gcc... ccache cc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables...
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether the compiler supports GNU C... yes
checking whether ccache cc accepts -g... yes
checking for ccache cc option to enable C11 features... none needed
checking build system type... x86_64-slackware-linux-gnu
checking host system type... x86_64-slackware-linux-gnu
checking for flex... flex
checking for lex output file root... lex.yy
checking for lex library... none needed
checking whether yytext is a pointer... yes
checking for bison... bison -y
checking for chown... chown
checking for chgrp... chgrp
checking for chmod... chmod
checking for windres... windres
checking for xz... /usr/bin/xz
checking for compression support... /usr/bin/xz
checking for suffix of compressed files... .xz
checking for stdio.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for strings.h... yes
checking for sys/stat.h... yes
checking for sys/types.h... yes
checking for unistd.h... yes
checking for ncurses.h... yes
checking for curses.h... yes
checking for termcap.h... yes
checking for library containing tparm... -lncursesw
checking for library containing has_colors... none required
checking for ncurses.h... (cached) yes
checking for curses.h... (cached) yes
checking for termcap.h... (cached) yes
checking for locale.h... yes
checking for library containing tparm... (cached) -lncursesw
checking for library containing has_colors... (cached) none required
checking for valid window system configuration... yes
checking for inttypes.h... (cached) yes
checking for stdint.h... (cached) yes
checking for unistd.h... (cached) yes
checking for string.h... (cached) yes
checking for utime.h... yes
checking for regex.h... yes
checking for ccache cc options needed to detect all undeclared functions... none needed
checking whether regcomp is declared... yes
checking whether strncmpi is declared... no
checking whether strnicmp is declared... no
checking for msleep... no
checking for usleep... yes
checking for fcntl... yes
checking for uint32_t... yes
checking for uint64_t... yes
checking for nroff... yes
checking for tbl... yes
checking for col... yes
checking for pseudo random number device... /dev/urandom
checking whether to enable data-librarian... no
checking whether to enable sinks... yes
checking whether to enable wallified-maze... yes
checking whether to enable reincarnation... yes
checking whether to enable blackmarket... yes
checking whether to enable kops... yes
checking whether to enable seduce... yes
checking whether to enable randomized-planes... yes
checking whether to enable steed... yes
checking whether to enable tourist... yes
checking whether to enable convict... yes
checking whether to enable redo... yes
checking whether to enable clipping... yes
checking whether to enable menu-color... yes
checking whether to enable status-color... yes
checking whether to enable auto-open... yes
checking whether to enable elbereth... yes
checking whether to enable bones-pool... yes
checking whether to enable user-sounds... no
checking whether to enable exp-on-botl... yes
checking whether to enable score-on-botl... no
checking whether to enable realtime-on-botl... no
checking whether to enable high-score-comparison-by-uid... no
checking whether to enable paranoid... yes
checking whether to enable shell... no
checking whether to enable show-born... yes
checking whether to enable show-extinct... yes
checking whether to enable sortloot... yes
checking whether to enable dungeon-growth... yes
checking whether to enable autopickup-exceptions... yes
checking whether to enable qwertz... yes
checking whether to enable simple-mail... no
checking whether to enable xlogfile... yes (file xlogfile)
checking whether to enable livelog... yes (file livelog)
checking whether to enable livelog-shout... no
checking whether to enable livelog-killing... no
checking whether to enable dump... yes
checking whether to enable dump file... no
checking whether to enable dump messages... yes (number 30)
checking whether to enable dump-text... yes
checking whether to enable dump-html... no
checking whether to enable sysconf... no
checking whether to enable utf8-glyphs... no
checking whether to enable whereis file... no
checking whether to enable wizmode... yes (user wizard)
checking for owner of installed files... games
checking for group of installed files... bin
checking whether to enable file-areas... yes
checking whether to enable debug-fuzzer... no
checking which directory is gamesdir... /var/lib/games/unnethack
checking which directory is bonesdir... /var/lib/games/unnethack/bones
checking which directory is savesdir... /var/lib/games/unnethack/saves
checking which directory is leveldir... /var/lib/games/unnethack/level
checking which directory is sharedir... /usr/share/games/unnethack
checking which directory is unsharedir... /usr/share/games/unnethack
configure: updating cache config.cache
configure: creating ./config.status
config.status: creating Makefile
config.status: creating src/Makefile
config.status: creating doc/Makefile
config.status: creating dat/Makefile
config.status: creating util/Makefile
config.status: creating sys/autoconf/depend.awk
config.status: creating include/autoconf.h
config.status: linking sys/winnt/win32api.h to include/win32api.h
echo '#ifndef AUTOCONF_PATH_H'  >include/autoconf_paths.h
echo '#undef AUTOCONF_PATH_H'  >>include/autoconf_paths.h
echo '#define AUTOCONF_PATH_H' >>include/autoconf_paths.h
echo '#define AUTOCONF_PREFIX  "/usr"' >>include/autoconf_paths.h
echo '#define AUTOCONF_LOCALSTATEDIR  "/var"' >>include/autoconf_paths.h
echo '#define AUTOCONF_DATADIR "/usr/share/games"' >>include/autoconf_paths.h
echo '#define AUTOCONF_DATAROOTDIR "/usr/share"' >>include/autoconf_paths.h
echo '#define AUTOCONF_DOCDIR "/usr/doc/unnethack-r2613"' >>include/autoconf_paths.h
echo '#endif' >>include/autoconf_paths.h
( cd src ; make )
make[1]: Entering directory '/usr/src/git/unnethack/src'
touch ../src/config.h-t
ccache cc -DAUTOCONF -Wall -I../include -I./../include -O2 -DHACKDIR=\"/var/lib/games/unnethack\"  -c ./monst.c
In file included from /usr/include/features.h:490,
                 from /usr/include/inttypes.h:25,
                 from ../include/config.h:306,
                 from ./monst.c:4:
/usr/include/sys/cdefs.h:405:73: error: macro "__has_attribute" requires an identifier
  405 | #if __GNUC_PREREQ (3,4) || __glibc_has_attribute (__warn_unused_result__)
      |                                                                         ^
make[1]: *** [Makefile:367: monst.o] Error 1
make[1]: Leaving directory '/usr/src/git/unnethack/src'
make: *** [Makefile:143: unnethack] Error 2
```

</details>
