### PR TITLE
Avoid "an ukulele"

### DIFF
--- a/src/objnam.c
+++ b/src/objnam.c
@@ -2046,6 +2046,7 @@ just_an(char *outbuf, const char *str)
              strncmpi(str, "uke", 3) && strncmpi(str, "ukulele", 7) &&
              strncmpi(str, "unicorn", 7) &&
              strncmpi(str, "uranium", 7) &&
+             strncmpi(str, "ukulele", 7) &&
              strncmpi(str, "useful", 6)) /* "useful tool" */ ||
                 (c0 == 'x' && !index(vowels, lowc(str[1])))) {
             Strcpy(outbuf, "an ");


### PR DESCRIPTION
"Ukulele" is one of the Hawaiian shirt designs, and an() was producing
"a ukulele" in the end-of-game disclosure and/or dumplog.  Add "ukulele"
to the list of vowel-initial words that should take "a" instead of "an".
