### PR TITLE
Simple change for Orion's ammo

### DIFF
--- a/dat/Ranger.des
+++ b/dat/Ranger.des
@@ -47,7 +47,7 @@ BRANCH:levregion(51,2,77,18),(0,0,40,20)
 MONSTER:('@',"Orion"),(20,10) {
   OBJECT:('[',"leather armor"),1d4
   OBJECT:(')',"yumi"),1d4
-  OBJECT:(')',"arrow"),1d4,quantity:10d5
+  OBJECT:(')',"ya"),1d4,quantity:10d5
 }
 # The treasure of Orion
 OBJECT:('(',"chest"),(20,10)


### PR DESCRIPTION
As in vanilla, one-line change to make sure the expert hunter has the proper ammo for his bow.